### PR TITLE
Fix : Changed the spelling of 'Quizes' to 'Quizzes'

### DIFF
--- a/Pages/3D-Visualizations/index.html
+++ b/Pages/3D-Visualizations/index.html
@@ -22,7 +22,7 @@
                   <li><a href="../About-Us/index.html" class="hover-link">About Us</a></li>
                   <li><a href="../Simulation/index.html" class="hover-link">Simulations</a></li>
                   <li><a href="../3D-Visualizations/index.html" class="hover-link">3D Visualisations</a></li>
-                  <li><a href="../Quizes/index.html" class="hover-link">Quizes</a></li>
+                  <li><a href="../Quizes/index.html" class="hover-link">Quizzes</a></li>
                   <li><a href="../Videos/index.html" class="hover-link">Videos</a></li>
                   <li><a href="../Doubt Engine/index.html" class="hover-link">Doubt Engine</a></li>
               </ul>

--- a/Pages/About-Us/index.html
+++ b/Pages/About-Us/index.html
@@ -22,7 +22,7 @@
                   <li><a href="../About-Us/index.html" class="hover-link">About Us</a></li>
                   <li><a href="../Simulation/index.html" class="hover-link">Simulations</a></li>
                   <li><a href="../3D-Visualizations/index.html" class="hover-link">3D Visualisations</a></li>
-                  <li><a href="../Quizes/index.html" class="hover-link">Quizes</a></li>
+                  <li><a href="../Quizes/index.html" class="hover-link">Quizzes</a></li>
                   <li><a href="../Videos/index.html" class="hover-link">Videos</a></li>
                   <li><a href="../Doubt Engine/index.html" class="hover-link">Doubt Engine</a></li>
               </ul>

--- a/Pages/Doubt Engine/index.html
+++ b/Pages/Doubt Engine/index.html
@@ -22,7 +22,7 @@
                   <li><a href="../About-Us/index.html" class="hover-link">About Us</a></li>
                   <li><a href="../Simulation/index.html" class="hover-link">Simulations</a></li>
                   <li><a href="../3D-Visualizations/index.html" class="hover-link">3D Visualisations</a></li>
-                  <li><a href="../Quizes/index.html" class="hover-link">Quizes</a></li>
+                  <li><a href="../Quizes/index.html" class="hover-link">Quizzes</a></li>
                   <li><a href="../Videos/index.html" class="hover-link">Videos</a></li>
                   <li><a href="../Doubt Engine/index.html" class="hover-link">Doubt Engine</a></li>
               </ul>

--- a/Pages/Quizes/index.html
+++ b/Pages/Quizes/index.html
@@ -22,7 +22,7 @@
                   <li><a href="../About-Us/index.html" class="hover-link">About Us</a></li>
                   <li><a href="../Simulation/index.html" class="hover-link">Simulations</a></li>
                   <li><a href="../3D-Visualizations/index.html" class="hover-link">3D Visualisations</a></li>
-                  <li><a href="../Quizes/index.html" class="hover-link">Quizes</a></li>
+                  <li><a href="../Quizes/index.html" class="hover-link">Quizzes</a></li>
                   <li><a href="../Videos/index.html" class="hover-link">Videos</a></li>
                   <li><a href="../Doubt Engine/index.html" class="hover-link">Doubt Engine</a></li>
               </ul>
@@ -38,7 +38,7 @@
     <!-- header section -->
     <header>
       <div class="header">
-        <h1>Quizes</h1>
+        <h1>Quizzes</h1>
         <img src="assets/asset 42.svg" alt="Simulation">
       </div>
     </header>

--- a/Pages/Simulation/index.html
+++ b/Pages/Simulation/index.html
@@ -22,7 +22,7 @@
                   <li><a href="../About-Us/index.html" class="hover-link">About Us</a></li>
                   <li><a href="../Simulation/index.html" class="hover-link">Simulations</a></li>
                   <li><a href="../3D-Visualizations/index.html" class="hover-link">3D Visualisations</a></li>
-                  <li><a href="../Quizes/index.html" class="hover-link">Quizes</a></li>
+                  <li><a href="../Quizes/index.html" class="hover-link">Quizzes</a></li>
                   <li><a href="../Videos/index.html" class="hover-link">Videos</a></li>
                   <li><a href="../Doubt Engine/index.html" class="hover-link">Doubt Engine</a></li>
               </ul>

--- a/index.html
+++ b/index.html
@@ -60,7 +60,7 @@
           <li><a href="./Pages/About-Us/index.html" class="hover-link">About Us</a></li>
           <li><a href="./Pages/Simulation/index.html" class="hover-link">Simulations</a></li>
           <li><a href="./Pages/3D-Visualizations/index.html" class="hover-link">3D Visualisations</a></li>
-          <li><a href="./Pages/Quizes/index.html" class="hover-link">Quizes</a></li>
+          <li><a href="./Pages/Quizes/index.html" class="hover-link">Quizzes</a></li>
           <li><a href="./Pages/Videos/index.html" class="hover-link">Videos</a></li>
           <li><a href="./Pages/Doubt Engine/index.html" class="hover-link">Doubt Engine</a></li>
         </ul>
@@ -126,7 +126,7 @@
         </div>
         <div class="features-card flex">
           <img src="./assets/asset 14.svg" alt="">
-          <h3>Quizes</h3>
+          <h3>Quizzes</h3>
           <p>Pinpoint knowledge gaps and improve understanding with personalized quiz feedback.</p>
           <a href="./Pages/Quizes/index.html" class="secondary-button">Learn more <i
               class="fa-solid fa-right-long"></i></a>
@@ -199,7 +199,7 @@
       </div>
       <div class=" feature-desc flex left">
         <h4>Step 4</h4>
-        <h3>Give Quizes</h3>
+        <h3>Give Quizzes</h3>
         <p>Test interfaces, interaction flows, iconography and more, to help you create intuitive and delightful
           experiences for your users.</p>
       </div>
@@ -235,7 +235,7 @@
             <span class="icon check"><i class="fas fa-check"></i></span>
           </li>
           <li>
-            <span class="list-name">Quizes</span>
+            <span class="list-name">Quizzes</span>
             <span class="icon check"><i class="fas fa-check"></i></span>
           </li>
           <li>
@@ -279,7 +279,7 @@
             <span class="icon check"><i class="fas fa-check"></i></span>
           </li>
           <li>
-            <span class="list-name">Quizes</span>
+            <span class="list-name">Quizzes</span>
             <span class="icon check"><i class="fas fa-check"></i></span>
           </li>
           <li>
@@ -302,7 +302,7 @@
           <h2>CareerLaunch <br>Accelerator</h2>
         </div>
         <div class="aj_p">
-          <p>Prepare for your dream career, which includes video lectures, simulations, 3D Visualisations, Quizes, and a
+          <p>Prepare for your dream career, which includes video lectures, simulations, 3D Visualisations, Quizzes, and a
             Doubt Engine to resolve doubts.</p>
         </div>
         <div class="price-section">
@@ -322,7 +322,7 @@
             <span class="icon check"><i class="fas fa-check"></i></span>
           </li>
           <li>
-            <span class="list-name">Quizes</span>
+            <span class="list-name">Quizzes</span>
             <span class="icon check"><i class="fas fa-check"></i></span>
           </li>
           <li>


### PR DESCRIPTION
<!-- Pull Request Template -->

## Related Issue

Closes #46 

<!-- If there is no issue number, the PR will not be merged. Therefore, please ensure that the issue number is added -->

## Description

The spelling of 'Quizes' has now been changed to 'Quizzes' everywhere on the website.

## Screenshots (if applicable)

## original screenshot    
 ![image](https://github.com/JAYESHBATRA/Virtuo-Learn/assets/103977344/1d75256f-8509-43fc-b6fa-f5c9d505e2c6) 
## updated screenshot 
 ![image](https://github.com/JAYESHBATRA/Virtuo-Learn/assets/103977344/439c56b1-fe76-4b3d-b1f8-bccd71f2fc4d) 


## Checklist 

<!-- [x] - To mark checked, put 'x' in place of ' '(space)  -->
<!-- [ ] - Keep unchecked using ' '(space)  -->

- [x] My code adheres to the established style guidelines of the project.
- [x] I have included comments in areas that may be difficult to understand.
- [x] My changes have not introduced any new warnings.
- [x] I have conducted a self-review of my code.