### PR TITLE
text selection bug solved in home page

### DIFF
--- a/style.css
+++ b/style.css
@@ -36,6 +36,12 @@ html.sr .load-hidden {
   background: linear-gradient(to top, #2294ed , #1d69a3);
 }
 
+
+::selection {
+    background: var(--accent-color);
+    color: #fff;
+}
+
 body {
 	font-family: "Poppins", sans-serif;
 	color: var(--primary-text-color);


### PR DESCRIPTION
<!-- Pull Request Template -->

## Related Issue

Closes #60

<!-- If there is no issue number, the PR will not be merged. Therefore, please ensure that the issue number is added -->

## Description
The bug is solved in the home page when choosing text within headings, paragraphs, or buttons on the website, it will not disappear or vanished.

<!-- Write a brief description of the changes made in the PR. Explain the problem being addressed, or any relevant
information. -->

## Screenshots (if applicable)

|      Original       |      Updated       |
| :-----------------: | :----------------: |
|
![Screenshot 2024-01-03 200402](https://github.com/JAYESHBATRA/Virtuo-Learn/assets/118626392/b2f83b37-91c9-427f-8445-3b9da17482cc)
 | 
![Screenshot 2024-01-03 205135](https://github.com/JAYESHBATRA/Virtuo-Learn/assets/118626392/21914626-a397-49be-a5b1-682d6396bcaf)
 |

## Checklist 

<!-- [x] - To mark checked, put 'x' in place of ' '(space)  -->
<!-- [ ] - Keep unchecked using ' '(space)  -->
- [x] My code adheres to the established style guidelines of the project.
- [x] I have included comments in areas that may be difficult to understand.
- [x] My changes have not introduced any new warnings.
- [x] I have conducted a self-review of my code.