### PR TITLE
Fix Quiz Heading

### DIFF
--- a/Pages/Quizes/index.html
+++ b/Pages/Quizes/index.html
@@ -23,7 +23,7 @@
                   <li><a href="../About-Us/index.html" class="hover-link">About Us</a></li>
                   <li><a href="../Simulation/index.html" class="hover-link">Simulations</a></li>
                   <li><a href="../3D-Visualizations/index.html" class="hover-link">3D Visualisations</a></li>
-                  <li><a href="../Quizes/index.html" class="hover-link">Quizes</a></li>
+                  <li><a href="../Quizes/index.html" class="hover-link">Quizzes</a></li>
                   <li><a href="../Videos/index.html" class="hover-link">Videos</a></li>
                   <li><a href="../Doubt Engine/index.html" class="hover-link">Doubt Engine</a></li>
               </ul>
@@ -39,7 +39,7 @@
     <!-- header section -->
     <header>
       <div class="header">
-        <h1 class="head-txt">Quizes</h1>
+        <h1 class="head-txt">Quizzes</h1>
         <img src="assets/asset 42.svg" alt="Simulation" class="head-img">
       </div>
     </header>

--- a/Pages/Videos/index.html
+++ b/Pages/Videos/index.html
@@ -23,7 +23,7 @@
                   <li><a href="../About-Us/index.html" class="hover-link">About Us</a></li>
                   <li><a href="../Simulation/index.html" class="hover-link">Simulations</a></li>
                   <li><a href="../3D-Visualizations/index.html" class="hover-link">3D Visualisations</a></li>
-                  <li><a href="../Quizes/index.html" class="hover-link">Quizes</a></li>
+                  <li><a href="../Quizes/index.html" class="hover-link">Quizzes</a></li>
                   <li><a href="../Videos/index.html" class="hover-link">Videos</a></li>
                   <li><a href="../Doubt Engine/index.html" class="hover-link">Doubt Engine</a></li>
               </ul>


### PR DESCRIPTION
**Closes #108**

**## Description**

This issue fixes the Quiz heading on the Quiz Page and the Video Lecture Page.


**## Screenshots **
The changes before and after can be seen in the below attached screenshots.

**Before :**

![image](https://github.com/JAYESHBATRA/Virtuo-Learn/assets/112249927/743a8351-aa1b-46d1-b8f6-a6755829fb8d)
![image](https://github.com/JAYESHBATRA/Virtuo-Learn/assets/112249927/12467aa9-7e0a-4d3b-8c7b-2884da7fe213)

**After :** 

![image](https://github.com/JAYESHBATRA/Virtuo-Learn/assets/112249927/b44d9a39-fd33-414b-b2ae-c6de7ebd58ce)
![image](https://github.com/JAYESHBATRA/Virtuo-Learn/assets/112249927/b7a8f6cb-9029-42b5-91dc-4c26d9f7fa19)


## Checklist 

<!-- [x] - To mark checked, put 'x' in place of ' '(space)  -->
<!-- [ ] - Keep unchecked using ' '(space)  -->

- [x] My code adheres to the established style guidelines of the project.
- [x] I have included comments in areas that may be difficult to understand.
- [x] My changes have not introduced any new warnings.
- [x] I have conducted a self-review of my code.