### PR TITLE
feat: add workflow for auto author assign

### DIFF
--- a/.github/workflows/auto-author-assign.yml
+++ b/.github/workflows/auto-author-assign.yml
@@ -1,0 +1,14 @@
+name: Auto Author Assign
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign-author:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: toshimaru/auto-author-assign@v2.1.0


### PR DESCRIPTION
### Related issue
This PR resolves the issue #165  

**Description:**
This pull request addresses the need for a streamlined process by introducing an automated workflow to assign the pull request author as the assignee. This enhancement ensures that the person initiating the changes is automatically assigned, simplifying the assignment process.

**Files added**
- `.github/workflows/auto-author-assign.yml`

**Proposed Changes:**
Introduce a GitHub Action that automatically assigns the pull request author as an assignee when a new pull request is created.

**Expected Behavior:**
Upon creating a pull request, the GitHub Action will automatically assign the pull request author, enhancing the efficiency of the assignment process.

@JAYESH-BATRA please review this PR.
Thanks