### PR TITLE
Issue No #182 [BUG FIXED] In the footer section, the copyright year should be dynamically generated instead of being statically hardcoded.

### DIFF
--- a/copyrightYear.js
+++ b/copyrightYear.js
@@ -1,0 +1,4 @@
+let copyRightYear = document.getElementById("copyright-year");
+let currentDate = new Date();
+let currentYear = currentDate.getFullYear();
+copyRightYear.innerText = currentYear;

--- a/index.html
+++ b/index.html
@@ -521,7 +521,7 @@
       </div>
       <div class="copyright">
         <h3>
-          Copyright &copy; 2024 Virtuo Learn | All rights reserved | Developed
+          Copyright &copy; <span id="copyright-year"></span> Virtuo Learn | All rights reserved | Developed
           By <a href="https://github.com/JAYESHBATRA">Jayesh Batra</a>
         </h3>
       </div>
@@ -563,5 +563,7 @@
     </script>
     <script src="scroll-reveal.js"></script>
     <script src="mode-switch.js"></script>
+      <!-- copyright-year Script -->
+    <script src="./copyrightYear.js"></script>
   </body>
 </html>


### PR DESCRIPTION
<!-- Pull Request Template -->

## Related Issue

Closes #182 

<!-- If there is no issue number, the PR will not be merged. Therefore, please ensure that the issue number is added -->

## Description

<!-- Write a brief description of the changes made in the PR. Explain the problem being addressed, or any relevant
information. -->
In this Pull request, I have added the dynamically generated copyright year in the footer section of the site by replacing the statically hardcoded copyright year value. 


## Checklist 

<!-- [x] - To mark checked, put 'x' in place of ' '(space)  -->
<!-- [ ] - Keep unchecked using ' '(space)  -->

- [x] My code adheres to the established style guidelines of the project.
- [x] I have included comments in areas that may be difficult to understand.
- [x] My changes have not introduced any new warnings.
- [x] I have conducted a self-review of my code.