### PR TITLE
Issue No #183 [BUG FIXED] In social media section twitter logo is not showing.

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@
               src="assets/twitterLogo.jpg"
               alt="Twitter Logo"
               id="tw-logo"
-              style="border-radius: 50%; width: full"
+              style="border-radius: 50%; width: 100%"
             />
           </a>
         </li>


### PR DESCRIPTION
<!-- Pull Request Template -->

## Related Issue

Closes #183 

<!-- If there is no issue number, the PR will not be merged. Therefore, please ensure that the issue number is added -->

## Description

<!-- Write a brief description of the changes made in the PR. Explain the problem being addressed, or any relevant
information. -->
In this Pull request, I have made some changes to solve this bug by replacing the width value of the Twitter logo in the social media section with 100%.

` <img
              src="assets/twitterLogo.jpg"
              alt="Twitter Logo"
              id="tw-logo"
              style="border-radius: 50%; width: 100%"
            />
   `

## Screenshots (if applicable)

|      Original       |      Updated       |
| :-----------------: | :----------------: |
|<img width="960" alt="Screenshot 2024-02-18 021657" src="https://github.com/JAYESHBATRA/Virtuo-Learn/assets/85905403/7744ec6c-a768-4dce-a389-162f47a0cb2b"> | <img width="960" alt="Screenshot 2024-02-18 021511" src="https://github.com/JAYESHBATRA/Virtuo-Learn/assets/85905403/a556afcf-c265-4214-9537-a8853d2f67b3"> |

## Checklist 

<!-- [x] - To mark checked, put 'x' in place of ' '(space)  -->
<!-- [ ] - Keep unchecked using ' '(space)  -->

- [x] My code adheres to the established style guidelines of the project.
- [x] I have included comments in areas that may be difficult to understand.
- [x] My changes have not introduced any new warnings.
- [x] I have conducted a self-review of my code.