### PR TITLE
fix: resolved- typewriter effect 

### DIFF
--- a/index.html
+++ b/index.html
@@ -168,7 +168,7 @@
         <div class="header-left">
           <div class="wrapper1">
             <div class="static-txt">Learn </div>
-            <div data-typewriter="Interactively,Engagingly,Enjoyingly,Happily"></div>
+            <div data-typewriter="Interactively,Engagingly,Intelligently,Happily"></div>
 <!--            insert words here-->
           </div>
 

--- a/index.html
+++ b/index.html
@@ -166,7 +166,63 @@
     <header>
       <div class="container header-section flex">
         <div class="header-left">
-          <h1 id="automatic-change">Learn Interactively</h1>
+          <div class="wrapper1">
+            <div class="static-txt">Learn </div>
+            <div data-typewriter="Interactively,Engagingly,Enjoyingly,Happily"></div>
+<!--            insert words here-->
+          </div>
+
+          <script>
+            class Typerwriter {
+              constructor(el, options){
+                this.el = el;
+                this.words = [...this.el.dataset.typewriter.split(',')];
+                this.speed = options?.speed || 100;
+                this.delay = options?.delay || 1500;
+                this.repeat = options?.repeat;
+                this.initTyping();
+              }
+
+              wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+              toggleTyping = () => this.el.classList.toggle('typing');
+
+              async typewrite(word){
+                await this.wait(this.delay);
+                this.toggleTyping();
+                for (const letter of word.split('')) {
+                  this.el.textContent += letter;
+                  await this.wait(this.speed)
+                }
+                this.toggleTyping();
+                await this.wait(this.delay);
+                this.toggleTyping();
+                while (this.el.textContent.length !== 0){
+                  this.el.textContent = this.el.textContent.slice(0, -1);
+                  await this.wait(this.speed)
+                }
+                this.toggleTyping();
+              }
+
+              async initTyping() {
+                for (const word of this.words){
+                  await this.typewrite(word);
+                }
+                if(this.repeat){
+                  await this.initTyping();
+                } else {
+                  this.el.style.animation = 'none';
+                }
+              }
+            }
+
+            document.querySelectorAll('[data-typewriter]').forEach(el => {
+              new Typerwriter(el, {
+                repeat: true,
+              })
+            })
+          </script>
+
           <p id="sub-para">
             Experience immersive learning like never before with simulations, 3D
             visualizations, customized quizzes, and videos all in one place!
@@ -185,18 +241,22 @@
       </div>
     </header>
 
-    <script type="text/javascript">
-      (function () {
-        var words = ["Learn Interactively", "Learn Engagingly"],
-          i = 0;
-        setInterval(function () {
-          $("#automatic-change").fadeOut(function () {
-            $(this)
-              .html(words[(i = (i + 1) % words.length)])
-              .fadeIn();
-          });
-        }, 2000);
-      })();
+<!--    <script type="text/javascript">-->
+<!--      (function () {-->
+<!--        var words = ["Learn Interactively", "Learn Engagingly"],-->
+<!--          i = 0;-->
+<!--        setInterval(function () {-->
+<!--          $("#automatic-change").fadeOut(function () {-->
+<!--            $(this)-->
+<!--              .html(words[(i = (i + 1) % words.length)])-->
+<!--              .fadeIn();-->
+<!--          });-->
+<!--        }, 2000);-->
+<!--      })();-->
+<!--    </script>-->
+
+    <script>
+
     </script>
 
     <!-- features section -->

--- a/style.css
+++ b/style.css
@@ -90,7 +90,7 @@ nav {
 	font-size: 3rem !important;
 	position: relative;
 	height: 2rem;
-	margin-left: 10px;
+	margin-left: 8px;
 }
 
 [data-typewriter]:not(.typing){

--- a/style.css
+++ b/style.css
@@ -79,10 +79,33 @@ nav {
       font-weight: normal;
       font-size: .80em;
     }
-h1 {
+.wrapper1{
 	font-size: 3rem !important;
 	position: relative;
 	z-index: -10;
+	display: flex;
+}
+
+[data-typewriter] {
+	font-size: 3rem !important;
+	position: relative;
+	height: 2rem;
+	margin-left: 10px;
+}
+
+[data-typewriter]:not(.typing){
+	animation: blink-caret 1.1s step-end infinite;
+}
+
+@keyframes blink-caret {
+	0%,
+	100% {
+		border-color: transparent
+	}
+
+	50% {
+		border-color: #ff8e3c;
+	}
 }
 
 h2 {


### PR DESCRIPTION


## Related Issue

Closes #225 

<!-- If there is no issue number, the PR will not be merged. Therefore, please ensure that the issue number is added -->

## Description

The fade in animation was removed. Now the words get backspaced except learn and new words appear beside learn. You can give as many words as well as possible. The script is attested in the body. CSS was preserved as it was in your file.

## Checklist 

<!-- [x] - To mark checked, put 'x' in place of ' '(space)  -->
<!-- [ ] - Keep unchecked using ' '(space)  -->

- [x] My code adheres to the established style guidelines of the project.
- [x] I have included comments in areas that may be difficult to understand.
- [x] My changes have not introduced any new warnings.
- [x] I have conducted a self-review of my code.