### PR TITLE
fix: Alignment of Heading in header #238

### DIFF
--- a/style.css
+++ b/style.css
@@ -48,6 +48,9 @@ body {
 	overflow-x: hidden;
 }
 #main_navbar {
+	/* given same padding to top and bottom  */
+	padding-top: 10px;
+	padding-bottom: 10px;
 	background-color: rgba(237, 225, 225, 0.144); /* Adjust the color and opacity as needed */
 	backdrop-filter: blur(70px);
         -webkit-backdrop-filter: blur(50px);
@@ -208,7 +211,7 @@ ul {
 /* nav bar */
 
 .main-nav {
-    margin-top: 20px;
+    /* margin-top: 20px; */
     justify-content: space-between;
 }
 


### PR DESCRIPTION

## Related Issue
The title Virtuo-learn is not properly aligned in the middle of the navbar and it can be easily seen in dark mode .

Closes #238 

## Description

This is happening because the div inside nav have a margin-top of 20px so by removing this i given same padding in navbar  
10px for top and same for bottom .

## Screenshots (if applicable)

|      Original       |      Updated       |
| :-----------------: | :----------------: |
|

![Screenshot 2024-05-15 131613](https://github.com/JAYESHBATRA/Virtuo-Learn/assets/118350936/b6982fb5-4654-4e18-8bac-b3e174f380e8)

 | ![Screenshot 2024-05-15 131511](https://github.com/JAYESHBATRA/Virtuo-Learn/assets/118350936/91e214c0-4856-42ef-820a-79966bb8f391) |

## Checklist 

- [  x ] My code adheres to the established style guidelines of the project.
- [  x ] I have included comments in areas that may be difficult to understand.
- [ x  ] My changes have not introduced any new warnings.
- [ x ] I have conducted a self-review of my code.