### PR TITLE
fix: Made changes to the font size and favicon size in nav bar

### DIFF
--- a/Pages/3D-Visualizations/style.css
+++ b/Pages/3D-Visualizations/style.css
@@ -319,10 +319,10 @@ nav {
     
     nav li {
        display: inline-block;
-       padding: 5px 5px;
+       padding: 6px 6px;
     }
     
     nav a {
       font-weight: normal;
-      font-size: .80em;
+      font-size: .90em;
     }

--- a/Pages/About-Us/style.css
+++ b/Pages/About-Us/style.css
@@ -64,10 +64,10 @@ nav {
     
     nav li {
        display: inline-block;
-       padding: 5px 5px;
+       padding: 6px 6px;
     }
     
     nav a {
       font-weight: normal;
-      font-size: .80em;
+      font-size: .90em;
     }

--- a/Pages/Doubt Engine/style.css
+++ b/Pages/Doubt Engine/style.css
@@ -83,10 +83,10 @@
     
     nav li {
        display: inline-block;
-       padding: 5px 5px;
+       padding: 6px 6px;
     }
     
     nav a {
       font-weight: normal;
-      font-size: .80em;
+      font-size: .90em;
     }

--- a/Pages/Quizes/style.css
+++ b/Pages/Quizes/style.css
@@ -355,10 +355,10 @@ nav {
     
     nav li {
        display: inline-block;
-       padding: 5px 5px;
+       padding: 6px 6px;
     }
     
     nav a {
       font-weight: normal;
-      font-size: .80em;
+      font-size: .90em;
     }

--- a/Pages/Simulation/style.css
+++ b/Pages/Simulation/style.css
@@ -318,10 +318,10 @@ nav {
     
     nav li {
        display: inline-block;
-       padding: 5px 5px;
+       padding: 6px 6px;
     }
     
     nav a {
       font-weight: normal;
-      font-size: .80em;
+      font-size: .90em;
     }

--- a/Pages/Videos/style.css
+++ b/Pages/Videos/style.css
@@ -323,10 +323,10 @@ nav {
     
     nav li {
        display: inline-block;
-       padding: 5px 5px;
+       padding: 6px 6px;
     }
     
     nav a {
       font-weight: normal;
-      font-size: .80em;
+      font-size: .90em;
     }

--- a/style.css
+++ b/style.css
@@ -163,7 +163,7 @@ nav {
     
     nav a {
       font-weight: normal;
-      font-size: .80em;
+      font-size: .88em;
     }
 .wrapper1{
 	font-size: 3rem !important;


### PR DESCRIPTION
Hello PA ,

Fixed Issue #227
As we can see below that the font and favicon size in  nav bar is small .
![Screenshot 2024-05-17 124037](https://github.com/JAYESHBATRA/Virtuo-Learn/assets/169278740/332e77ce-3ef4-4c12-84b9-e4982cc734f7)
![Screenshot 2024-05-17 124056](https://github.com/JAYESHBATRA/Virtuo-Learn/assets/169278740/60253b3f-b1b8-46f8-953f-516bdb5bd0d3)
 This is before making changes.The makes nav bar look not good.

So I have  made some changes Increased the font and fav icon size ,so that it is easily readable.
These are the changes I made:
![Screenshot 2024-05-17 124115](https://github.com/JAYESHBATRA/Virtuo-Learn/assets/169278740/305efa6b-150e-4c22-8d74-29fb7f47f791)
![Screenshot 2024-05-17 124135](https://github.com/JAYESHBATRA/Virtuo-Learn/assets/169278740/da515c33-396c-4adf-911f-a62a13b20fc5)
 I have made changes not just to home page but also the other 6 pages.
@JAYESHBATRA Please go through this PR and merge it and assign appropriate labels under GSSOC 2024.

Thank You.