### PR TITLE
Navbar in "Quizes" section is fixed

### DIFF
--- a/Pages/Quizes/tests/button-1/style.css
+++ b/Pages/Quizes/tests/button-1/style.css
@@ -141,7 +141,8 @@ ul {
 }
 
 .nav-links {
-    flex-basis: 730px;
+    /* flex-basis: 730px; */
+    display: grid;
 }
 
 .nav-menu{

--- a/Pages/Quizes/tests/button-10/style.css
+++ b/Pages/Quizes/tests/button-10/style.css
@@ -141,7 +141,8 @@ ul {
 }
 
 .nav-links {
-    flex-basis: 730px;
+    /* flex-basis: 730px; */
+    display: grid;
 }
 
 .nav-menu{

--- a/Pages/Quizes/tests/button-2/style.css
+++ b/Pages/Quizes/tests/button-2/style.css
@@ -141,7 +141,8 @@ ul {
 }
 
 .nav-links {
-    flex-basis: 730px;
+    /* flex-basis: 730px; */
+    display: grid;
 }
 
 .nav-menu{

--- a/Pages/Quizes/tests/button-3/style.css
+++ b/Pages/Quizes/tests/button-3/style.css
@@ -141,7 +141,8 @@ ul {
 }
 
 .nav-links {
-    flex-basis: 730px;
+    /* flex-basis: 730px; */
+    display: grid;
 }
 
 .nav-menu{

--- a/Pages/Quizes/tests/button-4/style.css
+++ b/Pages/Quizes/tests/button-4/style.css
@@ -141,7 +141,8 @@ ul {
 }
 
 .nav-links {
-    flex-basis: 730px;
+    /* flex-basis: 730px; */
+    display: grid;
 }
 
 .nav-menu{

--- a/Pages/Quizes/tests/button-5/style.css
+++ b/Pages/Quizes/tests/button-5/style.css
@@ -123,7 +123,8 @@ ul {
 }
 
 .nav-links {
-    flex-basis: 730px;
+    /* flex-basis: 730px; */
+    display: grid;
 }
 
 .nav-menu{

--- a/Pages/Quizes/tests/button-6/style.css
+++ b/Pages/Quizes/tests/button-6/style.css
@@ -123,7 +123,8 @@ ul {
 }
 
 .nav-links {
-    flex-basis: 730px;
+    /* flex-basis: 730px; */
+    display: grid;
 }
 
 .nav-menu{

--- a/Pages/Quizes/tests/button-7/style.css
+++ b/Pages/Quizes/tests/button-7/style.css
@@ -141,7 +141,8 @@ ul {
 }
 
 .nav-links {
-    flex-basis: 730px;
+    /* flex-basis: 730px; */
+    display: grid;
 }
 
 .nav-menu{

--- a/Pages/Quizes/tests/button-8/style.css
+++ b/Pages/Quizes/tests/button-8/style.css
@@ -123,7 +123,8 @@ ul {
 }
 
 .nav-links {
-    flex-basis: 730px;
+    /* flex-basis: 730px; */
+    display: grid;
 }
 
 .nav-menu{

--- a/Pages/Quizes/tests/button-9/style.css
+++ b/Pages/Quizes/tests/button-9/style.css
@@ -141,7 +141,8 @@ ul {
 }
 
 .nav-links {
-    flex-basis: 730px;
+    /* flex-basis: 730px; */
+    display: grid;
 }
 
 .nav-menu{


### PR DESCRIPTION
<!-- Pull Request Template -->

## Related Issue

Closes #396 

<!-- If there is no issue number, the PR will not be merged. Therefore, please ensure that the issue number is added -->

## Description

The "Quizes" section when opened was not showing the <a> tags of the navbar properly. The tags were not plaxced correctly. Some were coming in 2 lines which were having long headings.
However after fixing the navbar, this issue has been resolved.

## Screenshots (if applicable)

|      Original       |      Updated       |
| :-----------------: | :----------------: |
| ![virtuo-2](https://github.com/JAYESHBATRA/Virtuo-Learn/assets/135226069/b3d16d24-f88e-40d6-ae07-54fcd70b054f)| ![virtuo-3](https://github.com/JAYESHBATRA/Virtuo-Learn/assets/135226069/2a5df3c7-13cd-459c-8205-4aa41df59266) |

## Checklist 

<!-- [x] - To mark checked, put 'x' in place of ' '(space)  -->
<!-- [ ] - Keep unchecked using ' '(space)  -->

- [x] My code adheres to the established style guidelines of the project.
- [ ] I have included comments in areas that may be difficult to understand.
- [x] My changes have not introduced any new warnings.
- [x] I have conducted a self-review of my code.